### PR TITLE
Added Aqara LED lightbulb and Aqara 2-gang relay.

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -340,5 +340,21 @@
       <td><ul><li>getPower</li><li>getFanLevel</li><li>getFanSwing</li><li>getSleepMode</li><li>getBuzzer</li><li>getTimer</li></ul></td>
       <td><ul><li>setPower</li><li>setFanLevel</li><li>setSleepMode</li><li>setSwing</li><li>setSwingAngle</li><li>setBuzzer</li><li>setLcdBrightness</li><li>setTimer</li></ul></td>
     </tr>
+    <tr>
+      <td>42</td>
+      <td>lumi.light.aqcn02</td>
+      <td>Aqara LED Light Bulb (Tunable White)</td>
+      <td><img src="https://cdn.cnbj2.fds.api.mi-img.com/cdn/lumi/deviceImg/lumi.light.aqcn02.png" width="100"></td>
+      <td><ul><li>getPower</li><li>getBrightness</li><li>getColorTemperature</li></ul></td>
+      <td><ul><li>setPower</li><li>setBrightness</li><li>setColorTemperature</li></ul></td>
+    </tr>
+    <tr>
+      <td>43</td>
+      <td>lumi.relay.c2acn01</td>
+      <td>Aqara Wireless Relay Controller(2 Channels)</td>
+      <td><img src="https://cdn.cnbj2.fds.api.mi-img.com/cdn/lumi/deviceImg/lumi.relay.c2acn01.png" width="100"></td>
+      <td><ul><li>getPower</li><li>getLoadPower</li></ul></td>
+      <td><ul><li>setPower</li></ul></td>
+    </tr>
   </tbody>
 </table>

--- a/lib/devices/lumi.light.aqcn02.js
+++ b/lib/devices/lumi.light.aqcn02.js
@@ -1,0 +1,37 @@
+const Device = require('../device-miio');
+
+module.exports = class extends Device {
+  static model = 'lumi.light.aqcn02';
+  static name = 'Aqara LED Light Bulb (Tunable White)';
+  static image = 'https://cdn.cnbj2.fds.api.mi-img.com/cdn/lumi/deviceImg/lumi.light.aqcn02.png';
+
+  constructor(opts) {
+    super(opts);
+
+    this._propertiesToMonitor = [];
+  }
+
+  getPower() {
+    return this.miioCall('get_device_prop_exp', [[this.id, 'power_status']]);
+  }
+
+  getBrightness() {
+    return this.miioCall('get_device_prop_exp', [[this.id, 'light_level']]);
+  }
+
+  getColorTemperature() {
+    return this.miioCall('get_device_prop_exp', [[this.id, 'colour_temperature']]);
+  }
+
+  setPower(v) {
+    return this.miioCall('set_power', [v ? 'on' : 'off'], { sid: this.id });
+  }
+
+  setBrightness(v) {
+    return this.miioCall('set_bright', [v], { sid: this.id });
+  }
+
+  setColorTemperature(v) {
+    return this.miioCall('set_ct', [v], { sid: this.id });
+  }
+};

--- a/lib/devices/lumi.relay.c2acn01.js
+++ b/lib/devices/lumi.relay.c2acn01.js
@@ -1,0 +1,25 @@
+const Device = require('../device-miio');
+
+module.exports = class extends Device {
+  static model = 'lumi.relay.c2acn01';
+  static name = 'Aqara Wireless Relay Controller(2 Channels)';
+  static image = 'https://cdn.cnbj2.fds.api.mi-img.com/cdn/lumi/deviceImg/lumi.relay.c2acn01.png';
+
+  constructor(opts) {
+    super(opts);
+
+    this._propertiesToMonitor = [];
+  }
+
+  getPower(channel = 0) {
+    return this.miioCall('get_device_prop_exp', [[this.id, `channel_${channel}`]]);
+  }
+
+  getLoadPower() {
+    return this.miioCall('get_device_prop_exp', [[this.id, 'load_power']]);
+  }
+
+  setPower(v, channel = 0) {
+    return this.miioCall('toggle_ctrl_neutral', [`channel_${channel}`, v ? 'on' : 'off'], { sid: this.id });
+  }
+};

--- a/lib/protocol-miio.js
+++ b/lib/protocol-miio.js
@@ -318,6 +318,11 @@ class MiIOProtocol extends EventEmitter {
     };
     const device = this.getDevice(address);
 
+    if (options && options.sid) {
+      // If we have a sub-device set it (used by Lumi Smart Home Gateway)
+      request.sid = options.sid;
+    }
+
     return new Promise((resolve, reject) => {
       let resolved = false;
 


### PR DESCRIPTION
added the ability to manage the child gateway device via miio protocol

this.miioCall('toggle_ctrl_neutral', ['channel_0', 'on'], { sid: this.id })

sid is the device id