### PR TITLE
Fix EU Issues

### DIFF
--- a/lib/device-miio.js
+++ b/lib/device-miio.js
@@ -15,7 +15,7 @@ const sleep = time => {
 module.exports = class MiioDevice extends EventEmitter {
 
   constructor({
-    id, address, token, protocol, refresh,
+    id, address, token, protocol, refresh, country,
   }) {
     super();
     this.id = String(id);
@@ -33,6 +33,7 @@ module.exports = class MiioDevice extends EventEmitter {
       id,
       token,
     });
+    miCloudProtocol.setDefaultCountry(country);
   }
 
   get properties() {

--- a/lib/device-miio.js
+++ b/lib/device-miio.js
@@ -2,6 +2,7 @@ const EventEmitter = require('events');
 const fetch = require('node-fetch');
 const miioProtocol = require('./protocol-miio');
 const miCloudProtocol = require('./protocol-micloud');
+const debug = require('debug')('mihome:miio');
 
 const sleep = time => {
   return new Promise(resolve => {
@@ -87,21 +88,18 @@ module.exports = class MiioDevice extends EventEmitter {
         propsChunks.push(props.slice(i, i + chunkSize));
       }
 
-      let result = [];
       for (const propChunk of propsChunks) {
         const resultChunk = await this.getProperties(propChunk);
         if (!resultChunk) {
           throw new Error('Properties is empty');
         }
         if (resultChunk.length !== propChunk.length) {
-          throw new Error(`Result ${JSON.stringify(resultChunk)} and props ${JSON.stringify(propChunk)} does not match length`);
+          debug(`Result ${JSON.stringify(resultChunk)} and props ${JSON.stringify(propChunk)} does not match length`);
         }
-        result = result.concat(resultChunk);
+        propChunk.forEach((prop, i) => {
+          data[prop] = resultChunk[i];
+        });
       }
-      props.forEach((prop, i) => {
-        const value = result[i];
-        data[prop] = value;
-      });
       this._properties = Object.assign(this._properties, data);
       this.emit('available', true);
       this.emit('properties', data);

--- a/lib/protocol-micloud.js
+++ b/lib/protocol-micloud.js
@@ -29,6 +29,11 @@ class MiCloudProtocol {
 
     this.countries = ['ru', 'us', 'tw', 'sg', 'cn', 'de'];
     this.locale = 'en';
+    this.defaultCountry = 'cn';
+  }
+
+  setDefaultCountry(country = 'cn') {
+    this.defaultCountry = country;
   }
 
   get isLoggedIn() {
@@ -62,7 +67,7 @@ class MiCloudProtocol {
     this.serviceToken = null;
   }
 
-  async request(path, data, country = 'cn') {
+  async request(path, data, country = this.defaultCountry) {
     if (!this.isLoggedIn) {
       throw new Error('Pls login before make any request');
     }
@@ -138,7 +143,7 @@ class MiCloudProtocol {
     return data.result;
   }
 
-  _getApiUrl(country) {
+  _getApiUrl(country = this.defaultCountry) {
     country = country.trim().toLowerCase();
     return `https://${country === 'cn' ? '' : `${country}.`}api.io.mi.com/app`;
   }


### PR DESCRIPTION
Hi @maxinminax, I'm located in the EU and I've recently purchased a few Xiaomi smart home devices. While testing the NPM package, I found a couple of issues that I believe are the result of my Mi Account region settings (DE):
1. The Miio Device constructor doesn't allow to specify a country different than the default CN, this causes Mi Cloud calls to be performed to the Chinese API URL (which returns nothing).
2. Although further testing would be required to be 100% sure, I believe that the region settings influence the properties that can be retrieved for a given device. While testing with my `viomi.vacuum.v7`, multiple properties (defined in the device class) weren't available, I believe it's better to have a soft check for the length of the properties rather than throwing an invisible error.

Please let me know if there's anything I should change and/or improve, I'd be happy to contribute to the project on a regular basis.